### PR TITLE
Limit progress overflow in water tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,8 +211,8 @@
         };
         
         const WaterTracker = (completed, goal) => {
-            const progress = goal > 0 ? (completed / goal) * 100 : 0;
-            const portionsCompleted = Math.floor(completed / (goal / 6));
+            const progress = goal > 0 ? Math.min((completed / goal) * 100, 100) : 0;
+            const portionsCompleted = goal > 0 ? Math.min(Math.floor(completed / (goal / 6)), 6) : 0;
             return `
                 <div class="card p-6 rounded-2xl">
                     <div class="flex items-center gap-4 mb-4"><div style="color: var(--accent-water)"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22a7 7 0 0 0 7-7c0-2-1-3.9-3-5.5s-3.5-4-4-6.5c-.5 2.5-2 4.9-4 6.5C6 11.1 5 13 5 15a7 7 0 0 0 7 7z"></path></svg></div><div><h2 class="text-xl font-bold text-text-primary">Hidratação</h2><p class="text-sm text-text-secondary">Meta: ${goal/1000} litros</p></div></div>


### PR DESCRIPTION
## Summary
- avoid progress bar over 100% and handle invalid goals in water tracker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b4a897e508325b5973b6386054f77